### PR TITLE
workflow corrections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,13 +132,13 @@ jobs:
             ${{ runner.os }}-dotnet-tools-
 
       - name: 🌳 Install GitVersion
-        uses: gittools/actions/gitversion/setup@v1.1.1
+        uses: gittools/actions/gitversion/setup@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
         with:
           versionSpec: '5.x'
 
       - name: 🔢 Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v1.1.1
+        uses: gittools/actions/gitversion/execute@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
 
       - name: 📥 Restore dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,13 +132,13 @@ jobs:
             ${{ runner.os }}-dotnet-tools-
 
       - name: 🌳 Install GitVersion
-        uses: gittools/actions/gitversion/setup@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
+        uses: gittools/actions/gitversion/setup@1918cb0db30e20631f273e322d08c48af11db368 # v4.0.1
         with:
           versionSpec: '5.x'
 
       - name: 🔢 Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@dcb17efb49ec7f20efdebce79cc397a3952c63db # v1.2.0
+        uses: gittools/actions/gitversion/execute@1918cb0db30e20631f273e322d08c48af11db368 # v4.0.1
 
       - name: 📥 Restore dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           done
 
       - name: 🎉 Create GitHub Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,10 @@ jobs:
       - name: 🔢 Determine Version
         id: gitversion
         uses: gittools/actions/gitversion/execute@1918cb0db30e20631f273e322d08c48af11db368 #v4.0.1
+        with:
+          overrideConfig: |
+            mode=Mainline
+            branches.main.is-release-branch=true
 
       - name: 💬 Display Version Info
         run: |


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to use newer versions of actions and introduces configuration changes for versioning in the release workflow. The most important changes include upgrading the `gitversion` actions across workflows, adding an override configuration for versioning in the release workflow, and updating the `create-release` action.

### Updates to GitHub Actions versions:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L135-R141): Updated the `gittools/actions/gitversion/setup` and `gittools/actions/gitversion/execute` actions to use a specific commit hash corresponding to version `v4.0.1`.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L101-R105): Updated the `actions/create-release` action to use a specific commit hash corresponding to version `v1`.

### Configuration changes for versioning:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R72-R75): Added an `overrideConfig` parameter to the `gittools/actions/gitversion/execute` action, specifying `mode=Mainline` and marking the `main` branch as a release branch.