### PR TITLE
build process fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "next" ]
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
   pull_request:
     branches: [ "main", "next" ]
 
@@ -152,6 +153,14 @@ jobs:
         run: |
           dotnet build --configuration Release
           dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
+
+      - name: 📤 Upload NuGet packages to GitHub Packages
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          for file in $(find ${{ env.NuGetDirectory }} -name "*.nupkg" ! -name "*.symbols.nupkg" ! -name "*.snupkg"); do
+            echo "Publishing $file"
+            dotnet nuget push "$file" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate
+          done
 
       - name: 📎 Upload NuGet packages as artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Continuous Integration
 on:
   push:
     branches: [ "next" ]
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: [ "main", "next" ]
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the project, specifically enhancing the Continuous Integration pipeline. The changes include support for triggering builds on version tags and automating the upload of NuGet packages to GitHub Packages.

### Continuous Integration Enhancements:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R6-R8): Added support for triggering the workflow on version tags (`v*.*.*`) in addition to branch pushes and pull requests.

### NuGet Package Automation:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R157-R164): Added a new step to upload NuGet packages to GitHub Packages when the workflow is triggered by a tag. This step uses the `dotnet nuget push` command to publish packages, ensuring duplicates are skipped.