### PR TITLE
fix(ci): tune jobs to work the way I want

### DIFF
--- a/.github/workflows/devtool.yml
+++ b/.github/workflows/devtool.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup .NET 8 & 9
+      - name: ⚙️ Setup .NET 9
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         id: setup-dotnet-cf
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,11 +1,10 @@
-name: Continuous Integration
+name: Upload Packages
 
 on:
-  push:
-    branches: [ "next" ]
   workflow_dispatch:
-  pull_request:
-    branches: [ "main", "next" ]
+  push:
+    tags:
+      - 'v*.*.*'
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -13,22 +12,26 @@ env:
   NuGetDirectory: ${{ github.workspace}}/nuget
 
 jobs:
-  build:
-    name: Build and Test
+  package:
+    name: Create and Upload Packages
     runs-on: ubuntu-latest
+    # Permissions are required to create a release and publish packages.
+    permissions:
+      contents: write
+      packages: write
+    continue-on-error: true # This ensures that if the packaging job fails, the overall workflow status is not affected.
+    outputs:
+      packages: ${{ steps.list_packages.outputs.matrix }}
     steps:
       - name: 📝 Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 0
+            fetch-depth: 0 # required for gitversion to properly version
 
-      - name: ⚙️ Setup .NET 8 & 9
+      - name: ⚙️ Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
-        id: setup-dotnet
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
+          dotnet-version: 9.0.x # A single SDK version is sufficient for packaging.
 
       - name: 🥟 Setup Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
@@ -59,28 +62,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-dotnet-tools-
 
-      - name: 🌳 Install GitVersion
-        uses: gittools/actions/gitversion/setup@1918cb0db30e20631f273e322d08c48af11db368 #v4.0.1
-        with:
-          versionSpec: '6.x'
-
-      - name: 🔢 Determine Version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@1918cb0db30e20631f273e322d08c48af11db368 #v4.0.1
-
-      - name: 💬 Display Version Info
-        run: |
-          echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
-          echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
-
       - name: 📥 Restore dependencies
         run: |
           dotnet workload restore
           dotnet tool restore
           dotnet restore
 
-      - name: 🔨 Build
-        run: dotnet build --no-restore
+      - name: 📦 Create NuGet packages
+        run: |
+          dotnet build --configuration Release
+          dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
 
-      - name: 🚀 Test
-        run: dotnet test --no-build --verbosity normal
+      - name: 📤 Upload NuGet packages to GitHub Packages
+        run: |
+          for file in $(find ${{ env.NuGetDirectory }} -name "*.nupkg" ! -name "*.symbols.nupkg" ! -name "*.snupkg"); do
+            echo "Publishing $file"
+            dotnet nuget push "$file" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate
+          done
+
+      - name: 🎉 Attach Packages to GitHub Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: ${{ env.NuGetDirectory }}/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,13 +90,6 @@ jobs:
       - name: 📦 Create NuGet packages
         run: dotnet pack --configuration Release --no-build --output ${{ env.NuGetDirectory }}
 
-      - name: 📤 Upload NuGet packages to GitHub Packages
-        run: |
-          for file in $(find ${{ env.NuGetDirectory }} -name "*.nupkg" ! -name "*.symbols.nupkg" ! -name "*.snupkg"); do
-            echo "Publishing $file"
-            dotnet nuget push "$file" --api-key "${{ secrets.GITHUB_TOKEN }}" --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate
-          done
-
       - name: 🎉 Create GitHub Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
         env:
@@ -107,5 +100,4 @@ jobs:
           body: ${{ steps.gitversion.outputs.notes }}
           draft: false
           prerelease: ${{ steps.gitversion.outputs.preReleaseTag != '' }}
-          files: ${{ env.NuGetDirectory }}/*.nupkg
           make_latest: ${{ steps.gitversion.outputs.preReleaseTag == '' }}


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows to streamline packaging and release processes. The key changes include removing redundant packaging steps from existing workflows, introducing a dedicated workflow for package uploads, and updating .NET setup configurations.

### Workflow Refactoring

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L89-L170): Removed the `package` job, which included steps for creating and uploading NuGet packages. Packaging responsibilities have been moved to a dedicated workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L93-L99): Removed NuGet package upload steps from the release workflow, delegating this functionality to the new `package.yml`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L93-L99) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L110)

### New Workflow for Packaging

* [`.github/workflows/package.yml`](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R1-R88): Added a new workflow specifically for creating and uploading NuGet packages. This workflow includes steps for dependency restoration, package creation, and publishing to GitHub Packages, as well as attaching packages to GitHub releases.

### Configuration Updates

* [`.github/workflows/devtool.yml`](diffhunk://#diff-b5bc7e98fe9d5e631373b01e34e145894562a3d229ffa57dc400a355fcb24f08L31-R31): Updated .NET setup to use only version 9, removing support for version 8.
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L6-L7): Removed tag-based triggers for the `push` event, as these are now handled in the new `package.yml` workflow.